### PR TITLE
执行sea-orm-cli需要从环境变量中获取DATABASE_URL

### DIFF
--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -1,6 +1,11 @@
 use sea_orm_migration::prelude::*;
 
+use dotenv;
+use std::env::{self, Vars};
 #[async_std::main]
 async fn main() {
+    let _xx = dotenv::dotenv().ok();
+    let url = std::env::var("DATABASE_URL").expect("Environment variable 'DATABASE_URL' not set");
+    println!("DATABASE_URL:{:?}", url);
     cli::run_cli(migration::Migrator).await;
 }


### PR DESCRIPTION
1.不用设置环境变量，从env中获取DATABASE_URL。